### PR TITLE
Update requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,10 @@
 name: MeMoMe
 channels:
-  - rdkit
   - conda-forge
   - bioconda
   - defaults
   - anaconda
+  - rdkit
 dependencies:
   - cobra
   - debugpy


### PR DESCRIPTION
Apparently, the order of channels in the req. files define the order in which they searched for packages. By putting the rdkit channel first, you constrained conda to use an old rdkit version. There seems to be another on conda-forge, so I am not super sure if the rdkit channel is necessary. But tbh, I did not understand the versioning scheme of rdkit from looking at the different conda channels 

rdkit channel: https://anaconda.org/rdkit/rdkit
conda-forge chanel: https://anaconda.org/conda-forge/rdkit