### PR TITLE
Jan/feature/114

### DIFF
--- a/src/annotateInchiRoutines.py
+++ b/src/annotateInchiRoutines.py
@@ -2,10 +2,11 @@
 # 16.06.23
 from typing import Optional
 
-from src.matchMets import matchMetsByInchi
+from src.matchMets import matchMetsByInchi, NeutraliseCharges
 from rdkit import Chem, RDLogger
 from rdkit.DataStructs.cDataStructs import ExplicitBitVect
 import warnings
+
 
 from rdkit import Chem, RDLogger
 
@@ -97,7 +98,9 @@ def findOptimalInchi(inchis_: list[str], verbose:bool = False) -> Optional[str]:
 
                 nminchi1 = molToNormalizedInchi(m1)
                 nminchi2 = molToNormalizedInchi(m2)
-                k = k + int(matchMetsByInchi(nminchi1, nminchi2, m1, m2, molToRDK(m1), molToRDK(m2), verbose = verbose)[0])
+                nt_m1 = NeutraliseCharges(m1)
+                nt_m2 = NeutraliseCharges(m2)
+                k = k + int(matchMetsByInchi(nminchi1, nminchi2, m1, m2, molToRDK(m1), molToRDK(m2), nt_m1, nt_m2, verbose = verbose)[0])
         matches.append(k)
     if len(matches) == 0:
         return None

--- a/src/matchInchiRoutines.py
+++ b/src/matchInchiRoutines.py
@@ -4,6 +4,7 @@
 # Some functions to compare InChi keys/strings and tell if it is the same chemical structure
 
 import rdkit
+import warnings
 from rdkit import Chem, DataStructs, RDLogger
 from rdkit.Chem import AllChem
 from rdkit.Chem.EnumerateStereoisomers import EnumerateStereoisomers, StereoEnumerationOptions
@@ -161,8 +162,20 @@ def compareInchiByStereoIsomer0(m1:rdkit.Chem.rdchem.Mol, m2:rdkit.Chem.rdchem.M
      
     # find also stereoisomers in defined InChI
     opts = StereoEnumerationOptions(onlyUnassigned=False)
-    stereo1 = [Chem.MolToInchi(x) for x in EnumerateStereoisomers(m1, options=opts)]
-    stereo2 = [Chem.MolToInchi(x) for x in EnumerateStereoisomers(m2, options=opts)]
+    try:
+        stereo1 = [Chem.MolToInchi(x) for x in EnumerateStereoisomers(m1, options=opts)]
+    except RuntimeError as e:
+ #       warnings.warn(str(e))
+        stereo1 = [Chem.MolToInchi(m1)]
+        warnings.warn("Failed to enumerate steroisomers for "+stereo1[0]+ ". Will fallback to original structure without possible steroisomers")
+        warnings.warn("Will fallback to original structure without possible steroisomers")
+
+    try:
+        stereo2 = [Chem.MolToInchi(x) for x in EnumerateStereoisomers(m2, options=opts)]
+    except RuntimeError as e:
+        #warnings.warn(str(e)) 
+        stereo2 = [Chem.MolToInchi(m2)]
+        warnings.warn("Failed to enumerate steroisomers for " + stereo2[0] + ". Will fallback to original structure without possible steroisomers")
     intersect = list(set(stereo1).intersection(stereo2))
     return len(intersect) > 0
 

--- a/src/matchMets.py
+++ b/src/matchMets.py
@@ -10,14 +10,22 @@ from Levenshtein import ratio
 from warnings import warn
 from collections import namedtuple
 
-def matchMetsByInchi(nminchi1: str, nminchi2: str, mol1: Chem.rdchem.Mol, mol2: Chem.rdchem.Mol, fp1, fp2, verbose:bool = False) -> tuple:
+def matchMetsByInchi(nminchi1: str,
+        nminchi2: str,
+        mol1: Chem.rdchem.Mol,
+        mol2: Chem.rdchem.Mol,
+        fp1,
+        fp2,
+        charge_neutralized_mol1,
+        charge_neutralized_mol2,
+        verbose:bool = False) -> tuple:
     ''' A combination of different matching algorithms for the Inchi-Strings, which end in a simple yes/no answer, whether the molecules are the same'''
 
+    # rdkit is somewhat chatty. To supress the warning:
     # turn off chattiness of rdkit
     if verbose == False:
         RDLogger.DisableLog("rdApp.*")
 
-    # rdkit is somewhat chatty. To supress the warning:
     # check whether the molecules are differently charged, if so neutralize the charges
 #try:
     m1 = mol1
@@ -26,19 +34,23 @@ def matchMetsByInchi(nminchi1: str, nminchi2: str, mol1: Chem.rdchem.Mol, mol2: 
     charge2 = Chem.GetFormalCharge(m2)
     chargeDiff = charge1 - charge2
     if charge1 != charge2:
-        m1 = NeutraliseCharges(m1)
-        m2 = NeutraliseCharges(m2)
+        m1 = charge_neutralized_mol1
+        m2 = charge_neutralized_mol2
+ #       m1 = NeutraliseCharges(m1)
+ #       m2 = NeutraliseCharges(m2)
     
     same = False
+    # check the fingerprint
     if compareInchiByFingerprint0(fp1, fp2, verbose = verbose) == 1.0 or m1.GetNumAtoms() == m2.GetNumAtoms() == 1:
         same = nminchi1 == nminchi2
         if same == False:
-
             # if that is false check if there is one of the stereoisomers the
             # same
             same = compareInchiByStereoIsomer0(m1,m2, verbose = verbose)
 # finally:
     return(same, chargeDiff)
+
+
 
 DBResult = namedtuple("DBResult", ["commonDBs", "commonIds", "allIds", "score"])
 

--- a/tests/test_MeMoModel.py
+++ b/tests/test_MeMoModel.py
@@ -104,10 +104,12 @@ class Test_annotateBulkRoutines(unittest.TestCase):
         # test the comparison for metabolite matching
         mod_path = self.dat.joinpath("e_coli_core.xml")
         mod = MeMoModel.fromPath(mod_path)
+        mod.annotate()
         # self comparison
-        res = mod.match(mod)
+        res = mod.match(mod,keep1ToMany = False)
         self.assertIsInstance(res, pd.DataFrame)
         self.assertTrue(all([x in res.columns for x in ["met_id1","met_id2"]]))
+        self.assertTrue(all([x==y  for x,y in zip(res.met_id1,res.met_id2)]))
 
 
 class Test_MiscStuff(unittest.TestCase):

--- a/tests/test_MeMoModel.py
+++ b/tests/test_MeMoModel.py
@@ -28,9 +28,11 @@ class Test_annotateBulkRoutines(unittest.TestCase):
         mod_path = self.dat.joinpath("e_coli_core.xml")
         mod = MeMoModel.fromPath(mod_path)
         self.assertIsInstance(mod, MeMoModel)
+        self.assertIsInstance(mod.cobra_model, cb.Model)
         cb_mod = cb.io.read_sbml_model(str(mod_path))
         mod = MeMoModel.fromModel(cb_mod)
         self.assertIsInstance(mod, MeMoModel)
+        self.assertIsInstance(mod.cobra_model, cb.Model)
 
     def test_MeMoModelAnnotation(self):
         # load the e.coli core model and bulk annotate the metabolites. Check if any annoation tkes place (Chebi should cover all metabolites)

--- a/tests/test_matchInchi.py
+++ b/tests/test_matchInchi.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 
 from src.matchMets import matchMetsByInchi
-from src.annotateInchiRoutines import inchiToMol, molToRDK, molToNormalizedInchi
+from src.annotateInchiRoutines import inchiToMol, molToRDK, molToNormalizedInchi, NeutraliseCharges
 
 
 class TestMatchInchit(unittest.TestCase):
@@ -24,13 +24,18 @@ class TestMatchInchit(unittest.TestCase):
                 inchi2 = test_dat.loc[i,"Inchi2"]
                 m1 = inchiToMol(inchi1)
                 m2 = inchiToMol(inchi2)
-
                 nminchi1 = molToNormalizedInchi(m1)
                 nminchi2 = molToNormalizedInchi(m2)
+                ntmol1 = NeutraliseCharges(m1)
+                ntmol2 = NeutraliseCharges(m2)
 
-                res.append(matchMetsByInchi(nminchi1, nminchi2, m1, m2, molToRDK(m1), molToRDK(m2))[0])
+
+                res.append(matchMetsByInchi(nminchi1, nminchi2, m1, m2, molToRDK(m1), molToRDK(m2), ntmol1, ntmol2)[0])
         expected_res = [bool(x) for x in test_dat.loc[:,"Result"]]
         self.assertTrue(all([x==y for x,y in zip(expected_res,res)]))
+
+#    def test_matchMetsByInchi(self):
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes #131
Sped up the metabolite matching by precalculation for the neutralization of charge metabolites, implemented that errors during stereoisomer evaluation are caught and handled, yet handling is not perfect and fallback is only current inchi encoded stereoisomeric form of the metabolite (check compareInchiByStereoIsomer() function for details). Adjusted tests accordingly.