### PR TITLE
Refactored HMDB and VMH, SEED into common structure

### DIFF
--- a/src/annotation/annotateALL.py
+++ b/src/annotation/annotateALL.py
@@ -1,0 +1,58 @@
+import pandas as pd
+from src.download_db import get_config, get_database_path
+from src.MeMoMetabolite import MeMoMetabolite
+from src.annotation.annotateAux import AnnotationResult, load_database, handleIDs, handleMetabolites, EntryAnnotationFunction, DBName, AnnotationKey, DBKey
+from typing import Callable, List
+import json
+
+
+# TODO What exactly is STUFF
+def annotateDB(metabolites: list[MeMoMetabolite], db_name: DBName, annotation_key_name: DBKey, loading_function,  
+               entry_annotation_function: EntryAnnotationFunction , allow_missing_dbs: bool = False) -> AnnotationResult:
+  """
+  Annotate a list of metabolites with the entries from DB. Look for DB ids in the annotation slot of the metabolites and if one is found use these. 
+  The function will directly add the annotation and names to the MeMoMetabolite object.
+  Return value: a tuple of 3 denoting the number of changes metabolites for the following values: [inchi_strings, annotations, names]
+  """
+  db = load_database(get_config()["databases"][db_name]["file"], allow_missing_dbs, loading_function)
+
+  if db.empty:
+    return AnnotationResult(0, 0, 0)
+  return handleMetabolites(db, metabolites, annotation_key_name, entry_annotation_function)
+
+
+def annotateDB_entry(entry: AnnotationKey, db_name: DBName, loading_function,  
+                     handle_function: Callable[[pd.DataFrame, AnnotationKey], tuple[dict, list]],
+                     database: pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
+    """
+    A small helper function to avoid redundant code
+    Uses a DB identifiers and annotates it with the identifiers.org entries.
+    database - is either empty (default) or a pandas data.frame with the data from the DB for the metabolites. If it is empty, the function will try to load the database from the config file
+    Returns a tuple containing a dictionary for the extracted annotations and a list of new names for the metabolite
+    """
+    # check if the database was given, if not, try to load it
+    if len(database) > 0:
+      db = database
+    else:
+      db = load_database(get_config()["databases"][db_name]["file"], allow_missing_dbs, loading_function)
+    
+    if db.empty:
+      return dict(), list()
+
+    annotations, names = handle_function(db, entry)
+    return annotations, names
+
+
+def annotateDB_id(metabolites: list[MeMoMetabolite], db_name: DBName, db_key: DBKey, loading_function: Callable[[str], pd.DataFrame], 
+                   entry_annotation_function: EntryAnnotationFunction, allow_missing_dbs: bool = False) -> AnnotationResult:
+  """
+  Annotate a list of metabolites with the entries from DB . Look for DB ids in the metabolite._id slot and if one is found use these. 
+  """
+  # check if the database was given, if not, try to load it
+  db = load_database(get_config()["databases"][db_name]["file"], allow_missing_dbs, loading_function)
+  
+  if db.empty:
+    return AnnotationResult(0, 0, 0)
+  
+
+  return handleIDs(db, metabolites, db_key, entry_annotation_function)

--- a/src/annotation/annotateAux.py
+++ b/src/annotation/annotateAux.py
@@ -5,9 +5,20 @@ import pandas as pd
 from src.download_db import get_config, get_database_path
 import warnings
 import os
-from typing import Callable, List
+from typing import Callable, List, NewType
 from src.MeMoMetabolite import MeMoMetabolite
 import sys
+
+# HMDB0000972
+AnnotationKey = NewType('AnnotationKey', str)
+# Database name, corresponds to one of the keys in config.yaml
+DBName = NewType('DBName', str)
+# The dbs have have certain columns that correspond to their main identifier, e.g. vmh has vmhmetabolite, HMDB has accession and so one. This is what we call a database key. Aka the MAIN column which we use for entry lookup
+DBKey = NewType('DBKey', str)
+
+EntryAnnotationFunction = Callable[[AnnotationKey, pd.DataFrame, bool], tuple[dict, list]]
+
+
 
 class AnnotationResult():
   def __init__(self, annotated_inchis: int, annotated_dbs: int, annotated_names: int):
@@ -49,7 +60,7 @@ class AnnotationResult():
 
 
 def load_database(database: str = "", allow_missing_dbs: bool = False, 
-                  conversion_method: Callable[[str], pd.DataFrame] = lambda x: x) -> pd.DataFrame:
+                  conversion_method: Callable[[str], pd.DataFrame] = lambda x: pd.DataFrame()) -> pd.DataFrame:
   """
   Load the given database. The file should in the projects root /Database folder.
   """
@@ -65,7 +76,7 @@ def load_database(database: str = "", allow_missing_dbs: bool = False,
     db = pd.DataFrame()
   return(db)
 
-def handleIDs(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, annotation_function: Callable[[str, pd.DataFrame], tuple[dict, list]]) -> AnnotationResult:
+def handleIDs(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, entry_annotation_function: EntryAnnotationFunction, allow_missing_dbs: bool = False) -> AnnotationResult:
   """
   Checks for each metabolite if the metabolite id can be found in the column `db_key` can be found in `db`. 
   db: a dataframe with columns `db_key`. This column will be comparted to the metabolite id (met._id)
@@ -77,7 +88,8 @@ def handleIDs(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, 
   new_names = 0
   for met in metabolites:
     if any(db[db_key]==met._id):
-      new_met_anno_entry,new_names_entry = annotation_function(met._id, db)
+      #TODO FIX LAST PARaM
+      new_met_anno_entry,new_names_entry = entry_annotation_function(met._id, db, allow_missing_dbs)
       x = met.add_names(new_names_entry)
       new_names = new_names + x
 
@@ -92,16 +104,16 @@ def handleIDs(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, 
   return anno_result
 
 
-def handleMetabolites(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, annotation_function: Callable[[str, pd.DataFrame], tuple[dict, list]]) -> AnnotationResult:
+def handleMetabolites(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_key: str, annotation_function: EntryAnnotationFunction, allow_missing_dbs: bool = False) -> AnnotationResult:
     new_annos_added = 0
     new_names_added = 0
-    # go through the metabolites and check if there is data which can be added
+    # go through the metabolites and check if there is data whigh can be added
     for met in metabolites:
         new_met_anno = dict()
         new_names = list() 
         if db_key in met.annotations.keys():
             for entry in met.annotations[db_key]:
-                new_met_anno_entry, new_names_entry = annotation_function(entry, db)
+                new_met_anno_entry, new_names_entry = annotation_function(entry, db, allow_missing_dbs)
                 for key, value in new_met_anno_entry.items():
                     if key in new_met_anno.keys():
                         new_met_anno[key].extend(value)
@@ -118,6 +130,5 @@ def handleMetabolites(db: pd.DataFrame, metabolites: List[MeMoMetabolite], db_ke
             if len(new_met_anno) > 0:
                 x = met.add_annotations(new_met_anno)
                 new_annos_added = new_annos_added + x
-
     anno_result = AnnotationResult(0, new_names_added, new_names_added)
     return anno_result

--- a/src/annotation/annotateAux.py
+++ b/src/annotation/annotateAux.py
@@ -38,6 +38,9 @@ class AnnotationResult():
   def __str__(self) -> str:
     return f"Annotated inchis {self.annotated_inchis}, annotated dbs {self.annotated_dbs}, annotated names {self.annotated_names}"
 
+  def __repr__(self) -> str:
+    return f"Annotated inchis {self.annotated_inchis}, annotated dbs {self.annotated_dbs}, annotated names {self.annotated_names}"
+
   def __le__(self, other) -> bool:
     return self.annotated_inchis <= other.annotated_inchis and self.annotated_dbs <= other.annotated_dbs and self.annotated_names <= other.annotated_names
 

--- a/src/annotation/annotateHmdb.py
+++ b/src/annotation/annotateHmdb.py
@@ -1,11 +1,14 @@
 import json
 import pandas as pd
 from src.download_db import get_config
-from src.annotation.annotateAux import  load_database, AnnotationResult, handleMetabolites
+from src.annotation.annotateAux import  load_database, AnnotationResult, handleMetabolites, DBName, DBKey
 from src.MeMoMetabolite import MeMoMetabolite
 import warnings
+from src.annotation.annotateALL import *
 
-def normalize_hmdb_id(hmdb_id: str):
+
+
+def normalize_hmdb_id(hmdb_id: AnnotationKey) -> AnnotationKey:
   """
   params: A hmdb id
   VMH models contain keys like HMDB00972, but in HMDB the id is HMDB0000972. I.e. the digit part is 7 long not 5.
@@ -13,25 +16,23 @@ def normalize_hmdb_id(hmdb_id: str):
   prefix, numeric_part = hmdb_id[:4], hmdb_id[4:]
   if prefix.upper() != "HMDB":
     warnings.warn(f"The id ({hmdb_id}) is not a HMDB id. We will not look for matches. We are taking the first for characters ({prefix}) and capitalize it ({prefix.upper()}). If those are not HMDB we consider this an error.")
-    return ""
+    return AnnotationKey("")
   normalized_id = f"{prefix}{numeric_part.zfill(7)}"
-  return normalized_id
+  return AnnotationKey(normalized_id)
 
-def handle_HMDB_entries(hmdb, entry: str):
+def handle_HMDB_entries(hmdb: pd.DataFrame, entry: AnnotationKey):
+
   # VMH models contain keys like HMDB00972, but in HMDB the id is HMDB0000972. I.e. the digit part is 7 long not 5.
   entry = normalize_hmdb_id(entry)
   # The db col is called inchi, but it's inchi strings
   keys = ["accession",  "chemical_formula", "iupac_name", "traditional_iupac", "smiles", "inchi", "chebi_id", "pubchem_compound_id", "kegg_id", "biocyc_id", "bigg_id", "vmh_id"]
   hmdb = hmdb.loc[hmdb["accession"] == entry,]
-
-  pd.set_option('future.no_silent_downcasting', True)
-  hmdb = hmdb.replace(to_replace=r'\n', value='', regex=True)
   fullName = list(set(hmdb["name"]))
   hmdb = hmdb[keys]
   annotations = dict()
   if len(hmdb) > 1:
     raise Exception("More than one value for key: " + entry)
-
+  
   for index, row in hmdb.iterrows():
     for key, value in row.items():
       if (not pd.isna(value)) and (len(str(value)) > 0):
@@ -39,37 +40,13 @@ def handle_HMDB_entries(hmdb, entry: str):
         annotations.setdefault(key, []).append(value)
   return(annotations, fullName)
 
-def __load_csv(path) -> pd.DataFrame:
+def __load_csv(path: str) -> pd.DataFrame:
   df = pd.read_csv(path, low_memory=False)
   return(df)
 
 
-def annotateHMDB_entry(entry: str,  database: pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
-    # check if the database was given, if not, try to load it
-    if len(database) > 0:
-      hmdb = database
-    else:
-      hmdb = load_database(get_config()["databases"]["HMDB"]["file"], allow_missing_dbs, __load_csv)
-    
-    if hmdb.empty:
-      return dict(), list()
-
-    annotations, names = handle_HMDB_entries(hmdb, entry)
-    return annotations, names
-
-
+def annotateHMDB_entry(entry: AnnotationKey,  database: pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
+  return annotateDB_entry(entry, DBName("HMDB"), __load_csv, handle_HMDB_entries, database, allow_missing_dbs)
 
 def annotateHMDB(metabolites: list[MeMoMetabolite], allow_missing_dbs: bool = False) -> AnnotationResult:
-    """
-    Annotate a list of metabolites with the entries from VMH. Look for VMH ids in the annotation slot of the metabolites and if one is found use these.
-    The function will directly add the annotation and names to the MeMoMetabolite object.
-    Return value: a tuple of 3 denoting the number of changes metabolites for the following values: [inchi_strings, annotations, names]
-    """
-    
-    hmdb = load_database(get_config()["databases"]["HMDB"]["file"], allow_missing_dbs, __load_csv)
-    
-    if hmdb.empty:
-      return AnnotationResult(0, 0, 0)
-
-    return handleMetabolites(hmdb, metabolites, "hmdb", annotateHMDB_entry)
-
+  return  annotateDB(metabolites, DBName("HMDB"), DBKey("HMDB"), __load_csv, annotateHMDB_entry, allow_missing_dbs)

--- a/src/annotation/annotateModelSEED.py
+++ b/src/annotation/annotateModelSEED.py
@@ -103,6 +103,29 @@ def extractModelSEEDAnnotationsFromAlias(alias:str):
 #        
 #    return(new_anno_corrected)
 
+def handle_seed_id(aliases: pd.DataFrame) -> tuple[dict, list]:
+# get the information from the database
+  new_anno = dict()
+  new_names = list()
+  if len(aliases) >0:
+      for alias in aliases:
+          annos, names = extractModelSEEDAnnotationsFromAlias(alias)
+          # combine annos for the entry
+          for key,value in annos.items():
+              if key in new_anno.keys():
+                  new_anno[key].extend(value)
+              else:
+                  new_anno[key] = value
+          # combine names
+          new_names.extend(names)
+      
+      # remove duplicates
+      for key in new_anno.keys():
+          new_anno[key] = list(set(new_anno[key]))
+      new_names = list(set(new_names))
+
+  return(new_anno, new_names)
+
 
 def annotateModelSEED_entry(entry:str,  database:pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
     """
@@ -128,28 +151,9 @@ def annotateModelSEED_entry(entry:str,  database:pd.DataFrame = pd.DataFrame(), 
     aliases = mseed.loc[mseed["id"]==entry,"aliases"]
     # check if there are entries which are not NA
     aliases = aliases.loc[~pd.isna(aliases)]
-    # get the information from the database
-    new_anno = dict()
-    new_names = list()
-    if len(aliases) >0:
-        for alias in aliases:
-            annos, names = extractModelSEEDAnnotationsFromAlias(alias)
-            # combine annos for the entry
-            for key,value in annos.items():
-                if key in new_anno.keys():
-                    new_anno[key].extend(value)
-                else:
-                    new_anno[key] = value
-            # combine names
-            new_names.extend(names)
-        
-        # remove duplicates
-        for key in new_anno.keys():
-            new_anno[key] = list(set(new_anno[key]))
-        new_names = list(set(new_names))
+    return handle_seed_id(aliases)
     
 
-    return(new_anno, new_names)
 
 def annotateModelSEED_id(metabolites: list[MeMoMetabolite], allow_missing_dbs: bool = False) ->AnnotationResult:
     """

--- a/src/annotation/annotateVMH.py
+++ b/src/annotation/annotateVMH.py
@@ -9,10 +9,11 @@ import warnings
 from io import StringIO
 from src.download_db import get_config, get_database_path
 from src.MeMoMetabolite import MeMoMetabolite
-from src.annotation.annotateAux import AnnotationResult, load_database, handleIDs, handleMetabolites
-from typing import Optional
+from src.annotation.annotateAux import AnnotationResult, load_database, handleIDs, handleMetabolites, DBName, DBKey, AnnotationKey
+from src.annotation.annotateALL import *
+from typing import Optional, Tuple
 
-def handle_vmh_entries(vmh, entry):
+def handle_vmh_entries(vmh: pd.DataFrame, entry: str) -> Tuple[dict, list[str]]:
   keys = ["biggId", "keggId", "cheBlId", "inchiString", "inchiKey", "smile", "hmdb", "metanetx", "seed", "biocyc"]
   vmh = vmh.loc[vmh["abbreviation"] == entry,]
   fullName = list(set(vmh["fullName"]))
@@ -29,35 +30,20 @@ def handle_vmh_entries(vmh, entry):
 
   return(annotations, fullName)
 
-def __json_to_tsv(path) -> pd.DataFrame:
+def __json_to_tsv(path: str) -> pd.DataFrame:
   with open(path, "r") as f: 
     vmh = json.load(f)["results"]
     return(pd.DataFrame(vmh))
+                                      
 
-
-def annotateVMH_entry(entry: str,  database: pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
-    """
+def annotateVMH_entry(entry: AnnotationKey ,  database: pd.DataFrame = pd.DataFrame(), allow_missing_dbs: bool = False) -> tuple[dict, list]:
+  """
     A small helper function to avoid redundant code.
     Uses a VMH identifier and annotates it with the identifiers.org entries.
     database - is either empty (default) or a dictionary with the data from the VMH homepage for the metabolites. If it is empty, the function will try to load the database from the config file.
     Returns a tuple containing a dictionary for the extracted annotations and a list of new names for the metabolite.
     """
-
-    # check if the database was given, if not, try to load it
-    if len(database) > 0:
-      vmh = database
-    else:
-      vmh = load_database(get_config()["databases"]["VMH"]["file"], allow_missing_dbs, __json_to_tsv)
-    
-    if vmh.empty:
-      return dict(), list()
-
-    annotations, names = handle_vmh_entries(vmh, entry)
-    return annotations, names
-
-
-    
-
+  return annotateDB_entry(entry, DBName("VMH"), __json_to_tsv, handle_vmh_entries, database, allow_missing_dbs)
 
 
 def annotateVMH(metabolites: list[MeMoMetabolite], allow_missing_dbs: bool = False) -> AnnotationResult:
@@ -65,25 +51,13 @@ def annotateVMH(metabolites: list[MeMoMetabolite], allow_missing_dbs: bool = Fal
     Annotate a list of metabolites with the entries from VMH. Look for VMH ids in the annotation slot of the metabolites and if one is found use these.
     The function will directly add the annotation and names to the MeMoMetabolite object.
     Return value: a tuple of 3 denoting the number of changes metabolites for the following values: [inchi_strings, annotations, names]
-    """
-    
-    vmh = load_database(get_config()["databases"]["VMH"]["file"], allow_missing_dbs, __json_to_tsv)
-    
-    if vmh.empty:
-      return AnnotationResult(0, 0, 0)
+    """  
+    return annotateDB(metabolites, DBName("VMH"), DBKey("vmhmetabolite"), __json_to_tsv, annotateVMH_entry, allow_missing_dbs)
 
-    return handleMetabolites(vmh, metabolites, "vmhmetabolite", annotateVMH_entry)
 
 def annotateVMH_id(metabolites: list[MeMoMetabolite], allow_missing_dbs: bool = False) -> AnnotationResult:
-    """
-    Annotate a list of metabolites with the entries from VMH. Look for VMH ids in the metabolite._id slot and if one is found use these.
-    """
+  """
+  Annotate a list of metabolites with the entries from VMH. Look for VMH ids in the metabolite._id slot and if one is found use these.
+  """
+  return annotateDB_id(metabolites, DBName("VMH"), DBKey("abbreviation"), __json_to_tsv, annotateVMH_entry, allow_missing_dbs)
 
-    # check if the database was given, if not, try to load it
-    vmh = load_database(get_config()["databases"]["VMH"]["file"], allow_missing_dbs, __json_to_tsv)
-    
-    if vmh.empty:
-      return AnnotationResult(0, 0, 0)
-    
-
-    return handleIDs(vmh, metabolites, "abbreviation", annotateVMH_entry)

--- a/tests/test_annotate_dbs.py
+++ b/tests/test_annotate_dbs.py
@@ -320,6 +320,20 @@ class Test_annotateID(unittest.TestCase):
     self.assertEqual(ret, AnnotationResult(0, 1, 1))
 
 
+  def testSEED_id(self):
+    this_directory = Path(__file__).parent
+    dbs_dir = this_directory.parent/Path("Databases")
+    metabolite: MeMoMetabolite = MeMoMetabolite()
+    metabolite.set_id("cpd00002")
+    ret = annotateModelSEED_id([metabolite], allow_missing_dbs = False)
+    expected_annotations = {'AraCyc': ['ATP'], 'BiGG': ['atp'], 'BrachyCyc': ['ATP'], 'KEGG': ['C00002'], 'MetaCyc': ['ATP']}
+    expected_names = ['ATP', "Adenosine 5'-triphosphate", "adenosine-5'-triphosphate", 'adenosine-triphosphate', 'adenylpyrophosphate']
+
+    self.assertEqual(metabolite.annotations, expected_annotations)
+    self.assertEqual(metabolite.names, expected_names)
+    self.assertEqual(metabolite._inchi_string, "InChI=1S/C10H16N5O13P3/c11-8-5-9(13-2-12-8)15(3-14-5)10-7(17)6(16)4(26-10)1-25-30(21,22)28-31(23,24)27-29(18,19)20/h2-4,6-7,10,16-17H,1H2,(H,21,22)(H,23,24)(H2,11,12,13)(H2,18,19,20)/p-3/t4-,6-,7-,10-/m1/s1")
+
+
 class Test_annotateFull(unittest.TestCase):
   def testBiggAnnotate(self):
     metabolite: MeMoMetabolite = MeMoMetabolite()

--- a/tests/test_annotate_dbs.py
+++ b/tests/test_annotate_dbs.py
@@ -358,6 +358,19 @@ class Test_annotateFull(unittest.TestCase):
     self.assertEqual(metabolite.names, ['10-Formyltetrahydrofolate'])
     self.assertEqual(ret, AnnotationResult(0, 1, 1))
 
+
+  def testSEEDAnnotate(self):
+    metabolite: MeMoMetabolite = MeMoMetabolite()
+    metabolite.set_id('cpd00052')
+    metabolite.annotations = {'seed.compound': ['cpd00052']}
+    ret = annotateModelSEED([metabolite], allow_missing_dbs = False)
+    self.assertEqual(ret, AnnotationResult(1, 1, 1))
+
+    self.assertEqual(metabolite.names, ['CTP', "Cytidine 5'-triphosphate", 'Cytidine triphosphate', "cytidine-5'-triphosphate", 'cytidine-triphosphate'])
+    self.assertEqual(metabolite.annotations, {'seed.compound': ['cpd00052'], 'AraCyc': ['CTP'], 'BiGG': ['ctp'], 'BrachyCyc': ['CTP'], 'KEGG': ['C00063'], 'MetaCyc': ['CTP']})
+    self.assertEqual(metabolite._inchi_string, "InChI=1S/C9H16N3O14P3/c10-5-1-2-12(9(15)11-5)8-7(14)6(13)4(24-8)3-23-28(19,20)26-29(21,22)25-27(16,17)18/h1-2,4,6-8,13-14H,3H2,(H,19,20)(H,21,22)(H2,10,11,15)(H2,16,17,18)/p-3/t4-,6-,7-,8-/m1/s1")
+
+
   def testChEBIAnnotate(self):
     metabolite: MeMoMetabolite = MeMoMetabolite()
     metabolite.set_id('117228')

--- a/tests/test_annotate_dbs.py
+++ b/tests/test_annotate_dbs.py
@@ -4,11 +4,12 @@ import pandas as pd
 import os
 from unittest.mock import patch
 from io import *
-from src.annotation.annotateModelSEED import annotateModelSEED, annotateModelSEED_id, correctAnnotationKeys, annotateModelSEED_entry
+from src.annotation.annotateModelSEED import annotateModelSEED, annotateModelSEED_id, annotateModelSEED_entry
 from src.annotation.annotateChEBI import annotateChEBI
 from src.annotation.annotateBiGG import annotateBiGG, annotateBiGG_id, annotateBiGG_entry, handle_bigg_entries
 from src.annotation.annotateVMH import annotateVMH_entry, annotateVMH, annotateVMH_id
 from src.annotation.annotateHmdb import annotateHMDB_entry, annotateHMDB
+from src.annotation.annotateModelSEED import annotateModelSEED_entry, extractModelSEEDAnnotationsFromAlias, extractModelSEEDAnnotationsFromAlias2
 from src.annotation.annotateAux import AnnotationResult
 from src.MeMoMetabolite import MeMoMetabolite
 
@@ -273,6 +274,22 @@ class Test_annotateEntryFunctions(unittest.TestCase):
     self.assertEqual(ret, (dict(), list()))
 
 
+  def testSEEDEntry(self):
+    self.maxDiff = None
+    this_directory = Path(__file__).parent
+    dbs_dir = this_directory.parent/Path("Databases")
+    ret = annotateModelSEED_entry("cpd00052", allow_missing_dbs = False)
+    self.assertEqual(sorted(ret[1]), sorted(["cytidine-triphosphate",
+   "Cytidine triphosphate",
+   "Cytidine 5'-triphosphate",
+   "cytidine-5'-triphosphate",
+   "CTP"]))
+    print(ret[0])
+    self.assertFalse(len(ret[0]) == 0)
+
+    ret = annotateModelSEED_entry("", allow_missing_dbs = False)
+    self.assertEqual(ret, (dict(), list()))
+
 
 
 class Test_annotateID(unittest.TestCase):
@@ -346,3 +363,31 @@ class Test_annotateFull(unittest.TestCase):
     self.assertEqual(metabolite.annotations, expected_annotations)
     self.assertEqual(metabolite.names, ['10-Formyltetrahydrofolate'])
     self.assertEqual(ret, AnnotationResult(0, 1, 1))
+
+
+class Test_annotateAuxiliares(unittest.TestCase):
+
+  this_directory = Path(__file__).parent
+  dbs_dir = this_directory.parent/Path("Databases")
+
+  def test_extractModelSEEDAnnotationsFromAlias(self):
+    # Aliases of cpd00001
+    aliases1 = "Name: H20; H2O; H3O+; HO-; Hydroxide ion; OH; OH-; Water; hydrogen oxide; hydroxide; hydroxide ion; hydroxyl; hydroxyl ion; oxonium; water|AraCyc: OH; WATER|BiGG: h2o; oh1|BrachyCyc: WATER|KEGG: C00001; C01328|MetaCyc: OH; OXONIUM; WATER"
+
+    aliases2 = "Name: NADP(H); NADP-red; NADP-reduced; NADPH; NADPH+H+; NADPH2; Nicotinamide adenine dinucleotide phosphate - reduced; Nicotinamide adenine dinucleotide phosphate-reduced; Nicotinamideadeninedinucleotidephosphate-reduced; Reduced nicotinamide adenine dinucleotide phosphate; TPNH; beta-NADPH; dihydronicotinamide adenine dinucleotide phosphate; dihydronicotinamide adenine dinucleotide phosphate reduced; dihydronicotinamide adenine dinucleotide-P; dihydrotriphosphopyridine nucleotide; dihydrotriphosphopyridine nucleotide reduced; reduced NADP; reduced dihydrotriphosphopyridine nucleotide; reduced nicotinamide adenine dinucleotide phosphate|AraCyc: NADPH|BiGG: nadph|BrachyCyc: NADPH|KEGG: C00005|MetaCyc: NADPH"
+
+    # Aliases of cpd00002
+    aliases3 = "Name: ATP; Adenosine 5'-triphosphate; adenosine-5'-triphosphate; adenosine-triphosphate; adenylpyrophosphate|AraCyc: ATP|BiGG: atp|BrachyCyc: ATP|KEGG: C00002|MetaCyc: ATP"
+
+    expected1 = ({'AraCyc': ['OH', 'WATER'], 'BiGG': ['h2o', 'oh1'], 'BrachyCyc': ['WATER'], 'KEGG': ['C00001', 'C01328'], 'MetaCyc': ['OH', 'OXONIUM', 'WATER']}, ['H20', 'H2O', 'H3O+', 'HO-', 'Hydroxide ion', 'OH', 'OH-', 'Water', 'hydrogen oxide', 'hydroxide', 'hydroxide ion', 'hydroxyl', 'hydroxyl ion', 'oxonium', 'water'])
+    extracted1 = extractModelSEEDAnnotationsFromAlias(aliases1)
+    extracted11 = extractModelSEEDAnnotationsFromAlias2(aliases1)
+    print(extracted1)
+    print(extracted11)
+    #self.assertEqual(extracted1, expected1)
+
+    #extracted35 = extractModelSEEDAnnotationsFromAlias2(aliases3)
+    #expected3 = ({'AraCyc': ['ATP'], 'BiGG': ['atp'], 'BrachyCyc': ['ATP'], 'KEGG': ['C00002'], 'MetaCyc': ['ATP']}, ['ATP', "Adenosine 5'-triphosphate", "adenosine-5'-triphosphate", 'adenosine-triphosphate', 'adenylpyrophosphate'])
+    #print(extracted3)
+    #print(extracted35)
+    ##self.assertEqual(extracted3, expected3)


### PR DESCRIPTION
Mostly implements #194  and #196
Currently, three features were removed from ModelSeed
* pka,pkb
* identifier.org translation
* inchi annotation.

The last two should be implemented but in a more general way and for all dbs (especially the identifier.org translation). I'd strongly favor not reimplementing the pka,pkb stuff as long as we do not use it.

It probably would be worthwhile to implement a separate script that removes all unnecessary data from all the dbs and and also handles the translation. This would make the whole annotation super easy. But we would need to host our own copies of the dbs